### PR TITLE
Restrict ssh access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+.DS_Store
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# others
+config.yml
+/*.pem
+site-packages
+*.pem

--- a/README.md
+++ b/README.md
@@ -61,7 +61,15 @@ cd app
 npm install
 npm run build
 ```
-- Deploy backend CDK stack.
+
+- In `provisioning/bin/provisioning.ts`, modify  the value of `c9Eip` to Cloud9 public IP address. 
+
+```diff
+-  c9Eip: 'your-cloud9-ip'
++  c9Eip: 'xx.xx.xx.xx'
+```
+
+- After the modification, deploy backend CDK stack.
 ```sh
 cd ../provisioning
 npm install
@@ -97,6 +105,7 @@ chmod 600 ~/.ssh/keypair-alphafold2.pem
 
 - Now that the backend has been built, the next step is to create clusters for protein structure prediction.
 - In the Cloud9 IDE terminal, enter the following. 
+- You can modify config.yml to change instance type which is appropriate to your workload. 
 
 **NOTE**: The following includes commands for both AlphaFold2 and ColabFold. Choose one that you prefer.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -55,7 +55,15 @@ cd app
 npm install
 npm run build
 ```
-- バックエンドをビルドします
+
+- `provisioning/bin/provisioning.ts` にある `c9Eip` の値を Cloud9 のパブリップ IP アドレス に修正
+
+```diff
+-  c9Eip: 'your-cloud9-ip'
++  c9Eip: 'xx.xx.xx.xx'
+```
+
+- 修正後、バックエンドをビルドします
 ```sh
 cd ../provisioning
 npm install
@@ -75,6 +83,10 @@ chmod 600 ~/.ssh/keypair-alphafold2.pem
 ```
 
 ### 2. ParallelCluster クラスターの作成
+
+- バックエンドをデプロイしたら、次に ParallelCluster クラスターを作成します
+- Cloud9 IDE のターミナルで以下の手順に従ってコマンドを実行します
+- config.yml を修正することで、ワークロードに適したインスタンスタイプに変更することができます
 
 ```sh
 ## ParallelCluster コマンドのインストール

--- a/provisioning/bin/provisioning.ts
+++ b/provisioning/bin/provisioning.ts
@@ -8,7 +8,8 @@ const app = new cdk.App()
 const alphafold = new Alphafold2ServiceStack(app, `Alphafold2ServiceStack${CDK_ENV}`, {
   env: {
     region: 'us-east-1'
-  }
+  },
+  c9Eip: 'your-cloud9-ip'
 })
 
 const frontend = new FrontendStack(app, `FrontendStack${CDK_ENV}`, {

--- a/provisioning/hpc/alphafold2/config/config.template.yml
+++ b/provisioning/hpc/alphafold2/config/config.template.yml
@@ -6,6 +6,8 @@ HeadNode:
   Networking:
     SubnetId: ${PUBLIC_SUBNET}
     ElasticIp: true
+    SecurityGroups:
+     - ${HEADNODE_SG}
   Iam:
     S3Access:
       - BucketName: ${BUCKET_NAME}
@@ -45,13 +47,11 @@ Scheduling:
         S3Access:
           - BucketName: ${BUCKET_NAME}
             EnableWriteAccess: true
-        AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSNSFullAccess
     - Name: queue-gpu
       ComputeResources:
-        - Name: g54xlarge
+        - Name: g4dn2xlarge
           Instances:
-          - InstanceType: g4dn.4xlarge
+          - InstanceType: g4dn.2xlarge
           MinCount: 0
           MaxCount: 10
       Networking:
@@ -61,8 +61,6 @@ Scheduling:
         S3Access:
           - BucketName: ${BUCKET_NAME}
             EnableWriteAccess: true
-        AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSNSFullAccess
       CustomActions:
         OnNodeConfigured:
           Script: ${POST_INSTALL_SCRIPT_FOR_GPU_LOCATION}

--- a/provisioning/hpc/colabfold/config/config.template.yml
+++ b/provisioning/hpc/colabfold/config/config.template.yml
@@ -6,6 +6,8 @@ HeadNode:
   Networking:
     SubnetId: ${PUBLIC_SUBNET}
     ElasticIp: true
+    SecurityGroups:
+     - ${HEADNODE_SG}
   Iam:
     S3Access:
       - BucketName: ${BUCKET_NAME}
@@ -40,21 +42,15 @@ Scheduling:
       Networking:
         SubnetIds:
           - ${PRIVATE_SUBNET}
-      Iam:
-        AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSNSFullAccess
     - Name: queue-gpu
       ComputeResources:
-        - Name: g54xlarge
-          InstanceType: g5.4xlarge
+        - Name: g4dn2xlarge
+          InstanceType: g4dn.2xlarge
           MinCount: 0
           MaxCount: 10
       Networking:
         SubnetIds:
           - ${PRIVATE_SUBNET}
-      Iam:
-        AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSNSFullAccess
 
 SharedStorage:
   # Fsx for Lustreの設定

--- a/provisioning/hpc/colabfold/config/generate-template.ts
+++ b/provisioning/hpc/colabfold/config/generate-template.ts
@@ -46,6 +46,10 @@ async function getProvisionedEnv() {
   const AuroraPasswordArn = stack?.Outputs?.find((output) => {
     return output.OutputKey == 'AuroraPasswordArn'
   })?.OutputValue
+  
+  const HeadNodeSg = stack?.Outputs?.find((output) => {
+    return output.OutputKey == 'HeadNodeSecurityGroup'
+  })?.OutputValue
 
   const sm = new aws.SecretsManager({ region: REGION })
   const secretVal = await sm.getSecretValue({ SecretId: AuroraCredentialSecretArn! }).promise()
@@ -62,7 +66,8 @@ async function getProvisionedEnv() {
     dbUser: s.username,
     dbPass: s.password,
     dbName: s.dbname,
-    AuroraPasswordArn
+    AuroraPasswordArn,
+    HeadNodeSg
   }
 }
 
@@ -77,7 +82,8 @@ class SlurmConfigFileGenerator {
     private dbUser: string,
     private dbPass: string,
     private fsxId: string,
-    private AuroraPasswordArn: string
+    private AuroraPasswordArn: string,
+    private HeadNodeSg: string
   ) {}
 
   generate(props: { templatePath: string; outputPath: string }) {
@@ -99,6 +105,8 @@ class SlurmConfigFileGenerator {
       .replace(new RegExp('\\${REGION}', 'g'), REGION)
       .replace(new RegExp('\\${FSX_NAME}', 'g'), this.fsxId)
       .replace(new RegExp('\\${AURORA_PASSWORD_ARN}', 'g'), this.AuroraPasswordArn)
+      .replace(new RegExp('\\${FSX_NAME}', 'g'), this.fsxId)
+      .replace(new RegExp('\\${HEADNODE_SG}', 'g'), this.HeadNodeSg)
 
     try {
       fs.writeFileSync(props.outputPath, template)
@@ -121,7 +129,8 @@ async function main() {
     env.dbUser,
     env.dbPass,
     env.fsxId!,
-    env.AuroraPasswordArn!
+    env.AuroraPasswordArn!,
+    env.HeadNodeSg!
   )
   generator.generate({
     templatePath: path.join(__dirname, 'config.template.yml'),


### PR DESCRIPTION
Restrict ssh access to pCluster head node by attaching security group which only allow access from Cloud9 public ip address. 
