### PR TITLE
update README, 3dmol hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ chmod 600 ~/.ssh/keypair-alphafold2.pem
 
 ```sh
 ## Install AWS ParallelCluster CLI
-pip3 install aws-parallelcluster==3.3.0 --user
+pip3 install aws-parallelcluster==3.7.2 --user
 ## Set the default region
 export AWS_DEFAULT_REGION=us-east-1
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -115,7 +115,7 @@ chmod 600 ~/.ssh/keypair-alphafold2.pem
 
 ```sh
 ## ParallelCluster コマンドのインストール
-pip3 install aws-parallelcluster==3.3.0 --user
+pip3 install aws-parallelcluster==3.7.2 --user
 
 ## リージョンの設定
 export AWS_DEFAULT_REGION=us-east-1

--- a/app/index.html
+++ b/app/index.html
@@ -11,8 +11,9 @@
     <script type="module" src="/src/main.tsx"></script>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/3Dmol/1.4.0/3Dmol-min.js"
-      integrity="sha384-G/ktMxNGQtSajNFY+7He9WGWTfkmMrPlEbZbCjtjWLYXpsgvuAkS8Aj8IBjs13yc"
+      integrity="sha512-HsVz9Fut4tl5LnN4v1Z1JXRu8eRBMoWiVAEfBTIDbe6LOpKfIwLu1LpDPS3ag8P81PGfay6ozQ63V29oMKBwyw=="
       crossorigin="anonymous"
+      referrerpolicy="no-referrer"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Updated README (en, ja) to update ParallelCluster's version.
- Updated 3dmol library's cdnjs hash to avoid `None of the “sha384” hashes in the integrity attribute match the content of the subresource` error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
